### PR TITLE
Set futures version number to match the other repos

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ repository = "https://github.com/tokio-rs/tokio-service"
 readme = "README.md"
 
 [dependencies]
-futures = { git = "https://github.com/alexcrichton/futures-rs", default-features = false }
+futures = "0.1"


### PR DESCRIPTION
Currently tokio-proto doesn't compile, as futures have different versions.
