### PR TITLE
Proposal: Back pressure handling + take &mut self

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@ use std::sync::Arc;
 ///     type Error = http::Error;
 ///     type Fut = Box<Future<Item = Self::Resp, Error = http::Error>>;
 ///
-///     fn call(&self, req: http::Request) -> Self::Fut {
+///     fn call(&mut self, req: http::Request) -> Self::Fut {
 ///         // Create the HTTP response
 ///         let resp = http::Response::ok()
 ///             .with_body(b"hello world\n");
@@ -120,7 +120,7 @@ use std::sync::Arc;
 ///     type Error = T::Error;
 ///     type Fut = Box<Future<Item = Self::Resp, Error = Self::Error>>;
 ///
-///     fn call(&self, req: Self::Req) -> Self::Fut {
+///     fn call(&mut self, req: Self::Req) -> Self::Fut {
 ///         let timeout = self.timer.timeout(self.delay)
 ///             .and_then(|timeout| Err(Self::Error::from(timeout)));
 ///
@@ -152,7 +152,7 @@ pub trait Service {
     type Future: Future<Item = Self::Response, Error = Self::Error>;
 
     /// Process the request and return the response asynchronously.
-    fn call(&self, req: Self::Request) -> Self::Future;
+    fn call(&mut self, req: Self::Request) -> Self::Future;
 }
 
 /// Creates new `Service` values.
@@ -187,57 +187,13 @@ impl<F, R> NewService for F
     }
 }
 
-impl<S: NewService + ?Sized> NewService for Arc<S> {
-    type Request = S::Request;
-    type Response = S::Response;
-    type Error = S::Error;
-    type Instance = S::Instance;
-
-    fn new_service(&self) -> io::Result<S::Instance> {
-        (**self).new_service()
-    }
-}
-
-impl<S: NewService + ?Sized> NewService for Rc<S> {
-    type Request = S::Request;
-    type Response = S::Response;
-    type Error = S::Error;
-    type Instance = S::Instance;
-
-    fn new_service(&self) -> io::Result<S::Instance> {
-        (**self).new_service()
-    }
-}
-
 impl<S: Service + ?Sized> Service for Box<S> {
     type Request = S::Request;
     type Response = S::Response;
     type Error = S::Error;
     type Future = S::Future;
 
-    fn call(&self, request: S::Request) -> S::Future {
-        (**self).call(request)
-    }
-}
-
-impl<S: Service + ?Sized> Service for Rc<S> {
-    type Request = S::Request;
-    type Response = S::Response;
-    type Error = S::Error;
-    type Future = S::Future;
-
-    fn call(&self, request: S::Request) -> S::Future {
-        (**self).call(request)
-    }
-}
-
-impl<S: Service + ?Sized> Service for Arc<S> {
-    type Request = S::Request;
-    type Response = S::Response;
-    type Error = S::Error;
-    type Future = S::Future;
-
-    fn call(&self, request: S::Request) -> S::Future {
+    fn call(&mut self, request: S::Request) -> S::Future {
         (**self).call(request)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,8 +11,6 @@ extern crate futures;
 use futures::Future;
 
 use std::io;
-use std::rc::Rc;
-use std::sync::Arc;
 
 /// An asynchronous function from `Request` to a `Response`.
 ///
@@ -152,7 +150,33 @@ pub trait Service {
     type Future: Future<Item = Self::Response, Error = Self::Error>;
 
     /// Process the request and return the response asynchronously.
-    fn call(&mut self, req: Self::Request) -> Self::Future;
+    fn call(&mut self, req: Self::Request) -> AsyncService<Self::Future, Self::Request>;
+}
+
+/// The result of an asynchronous attempt to call a service.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum AsyncService<T, U> {
+    /// The `call` attempt succeeded, so the service has accepted the request.
+    Ready(T),
+
+    /// The `call` attempt failed due to the service being at capacity. The request is returned and
+    /// the current `Task` will be notified again once the service has capacity.
+    NotReady(U),
+}
+
+impl<T, U> AsyncService<T, U> {
+    /// Returns whether this is `AsyncService::Ready`
+    pub fn is_ready(&self) -> bool {
+        match *self {
+            AsyncService::Ready(_) => true,
+            AsyncService::NotReady(_) => false,
+        }
+    }
+
+    /// Returns whether this is `AsyncService::NotReady`
+    pub fn is_not_ready(&self) -> bool {
+        !self.is_ready()
+    }
 }
 
 /// Creates new `Service` values.
@@ -193,7 +217,7 @@ impl<S: Service + ?Sized> Service for Box<S> {
     type Error = S::Error;
     type Future = S::Future;
 
-    fn call(&mut self, request: S::Request) -> S::Future {
+    fn call(&mut self, request: S::Request) -> AsyncService<S::Future, S::Request> {
         (**self).call(request)
     }
 }


### PR DESCRIPTION
The PR represents my proposal for changes to `Service`.

`Service::call` is updated to follow `Sink` for handling back pressure. I also changed `Service::call` to take `&mut self` vs. `&self`.

/cc @aturon @alexcrichton @seanmonstar @danburkert