### PR TITLE
Introduce a Middleware trait.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,7 +104,7 @@ pub trait Service {
         M: Middleware<Self>,
         Self: Sized,
     {
-        WrappedService::new(Arc::new(self), middleware)
+        WrappedService::new(self, middleware)
     }
 }
 

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -1,0 +1,185 @@
+use std::io;
+use std::sync::Arc;
+
+use futures::Future;
+
+use {Service, NewService};
+
+/// A middleware wrapper around a Service.
+///
+/// More often than not, many of the pieces needed for writing robust, scalable
+/// network applications are the same no matter the underlying protocol. By
+/// unifying the API for both clients and servers in a protocol agnostic way,
+/// it is possible to write middleware that provide these pieces in a
+/// reusable way.
+///
+/// For example, take timeouts as an example:
+///
+/// ```rust,ignore
+/// use tokio::{Service, Middleware};
+/// use futures::Future;
+/// use std::time::Duration;
+/// use std::sync::Arc;
+///
+/// // Not yet implemented, but soon :)
+/// use tokio::timer::{Timer, Expired};
+///
+/// pub struct Timeout<T> {
+///     delay: Duration,
+///     timer: Timer,
+/// }
+///
+/// impl<T> Timeout<T> {
+///     pub fn new(delay: Duration) -> Timeout<T> {
+///         Timeout {
+///             delay: delay,
+///             timer: Timer::default(),
+///         }
+///     }
+/// }
+///
+/// impl<T> Middleware<T> for Timeout<T>
+///     where T: Service,
+///           T::Error: From<Expired>,
+/// {
+///     type Request = T::Request;
+///     type Response = T::Response;
+///     type Error = T::Error;
+///     type Future = Box<Future<Item = Self::Response, Error = Self::Error>>;
+///
+///     fn call(&self, req: Self::Req, service: &Arc<T>) -> Self::Future {
+///         let timeout = self.timer.timeout(self.delay)
+///             .and_then(|timeout| Err(Self::Error::from(timeout)));
+///
+///         service.call(req)
+///             .select(timeout)
+///             .map(|(v, _)| v)
+///             .map_err(|(e, _)| e)
+///             .boxed()
+///     }
+/// }
+///
+/// ```
+///
+/// The above timeout implementation is decoupled from the underlying protocol
+/// and is also decoupled from client or server concerns. In other words, the
+/// same timeout middleware could be used in either a client or a server.
+pub trait Middleware<S: Service + ?Sized> {
+    /// Requests handled by the middleware.
+    type Request;
+
+    /// Responses given by the middleware.
+    type Response;
+
+    /// Errors produced by the middleware.
+    type Error;
+
+    /// The future response value.
+    type Future: Future<Item = Self::Response, Error = Self::Error>;
+
+    /// Process the request and return the response asynchronously.
+    ///
+    /// This method receives a reference to the interior service that it is wrapping.
+    fn call(&self, req: Self::Request, service: &Arc<S>) -> Self::Future;
+
+    /// Wrap a service with this middleware.
+    fn wrap(self, service: Arc<S>) -> WrappedService<S, Self> where Self: Sized {
+        WrappedService::new(service, self)
+    }
+}
+
+/// Create a new `Middleware` values.
+pub trait NewMiddleware<S: NewService + ?Sized> {
+    /// Requests handled by the middleware.
+    type Request;
+
+    /// Responses given by the middleware.
+    type Response;
+
+    /// Errors produced by the middleware.
+    type Error;
+
+    /// The `Middleware` value created by this factory
+    type Instance: Middleware<S::Instance, Request = Self::Request, Response = Self::Response, Error = Self::Error>;
+
+    /// Create and return a new middleware value.
+    fn new_middleware(&self) -> io::Result<Self::Instance>;
+
+    /// Wrap a service factory with this middleware factory.
+    fn wrap(self, service_factory: S) -> ServiceWrapper<S, Self> where
+        S: Sized,
+        Self: Sized,
+    {
+        ServiceWrapper::new(service_factory, self)
+    }
+}
+
+/// A WrappedService is a Service wrapped in a Middleware. It can be
+/// constructed using the Service::wrap method.
+pub struct WrappedService<S: Service + ?Sized, M: Middleware<S>> {
+    service: Arc<S>,
+    middleware: M,
+}
+
+impl<S: ?Sized, M> Service for WrappedService<S, M> where
+    S: Service,
+    M: Middleware<S>,
+{
+    type Request = M::Request;
+    type Response = M::Response;
+    type Error = M::Error;
+    type Future = M::Future;
+
+    fn call(&self, req: Self::Request) -> Self::Future {
+        self.middleware.call(req, &self.service)
+    }
+}
+
+impl<S: ?Sized, M> WrappedService<S, M> where
+    S: Service,
+    M: Middleware<S>,
+{
+    /// Construct a new WrappedService from a Service and a Middleware.
+    pub fn new(service: Arc<S>, middleware: M) -> WrappedService<S, M> {
+        WrappedService {
+            service: service,
+            middleware: middleware,
+        }
+    }
+}
+
+/// A ServiceWrapper is a factory that constructs a service wrapped with a middleware.
+/// It can be constructed with the NewService::wrap method.
+pub struct ServiceWrapper<S: NewService, M: NewMiddleware<S>> {
+    service_factory: S,
+    middleware_factory: M,
+}
+
+impl<S, M> NewService for ServiceWrapper<S, M> where
+    S: NewService,
+    M: NewMiddleware<S>,
+{
+    type Request = M::Request;
+    type Response = M::Response;
+    type Error = M::Error;
+    type Instance = WrappedService<S::Instance, M::Instance>;
+
+    fn new_service(&self) -> io::Result<Self::Instance> {
+        let service = self.service_factory.new_service()?;
+        let middleware = self.middleware_factory.new_middleware()?;
+        Ok(WrappedService::new(Arc::new(service), middleware))
+    }
+}
+
+impl<S, M> ServiceWrapper<S, M> where
+    S: NewService,
+    M: NewMiddleware<S>,
+{
+    /// Construct a new ServiceWrapper from a NewService and a NewMiddleware.
+    pub fn new(service_factory: S, middleware_factory: M) -> ServiceWrapper<S, M> {
+        ServiceWrapper {
+            service_factory: service_factory,
+            middleware_factory: middleware_factory,
+        }
+    }
+}


### PR DESCRIPTION
The Middleware trait abstracts the composition of services and
middleware. Rather than each middleware component taking its upstream
service in its own manner, all of them receive a reference to an
upstream service as a part of their definition of call.

Some notes about this design:

The Middleware is parametric over Service, which allows users to
specify which sorts of Service their Middleware can wrap (for example,
if they need to implement another trait, or need to have a particular
Request, Response, or Error type).

The Middleware receives its upstream Service as an `&Arc<S>`. The inner
Service is stored in an Arc so that it can be cloned and returned as
part of the state of the future returned by this middleware (e.g. by
moving it into an AndThen call). However, it is passed by reference,
so that reference count need not be incremented.

For convenience, Middleware, Service, and their factory traits all have
a pre-implemented wrap method, which takes this middleware or service
and its corresponding pair, and construct a new service which wraps
the middleware around the service.  The return value of wrap implements
Service or NewService appropriately, so that it can continue to be
subjected to wrapping actions.

This allows users to conveniently write middleware chains, as in:

```rust
some_service.wrap(middleware1).wrap(middleware2).wrap(middleware3)
```