### PR TITLE
Middleware & Stream Services

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 mod middleware;
 pub mod stream;
 
-pub use self::middleware::{Middleware, MiddlewareChain};
+pub use self::middleware::*;
 
 /// An asynchronous function from `Request` to a `Response`.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,9 +102,9 @@ pub trait Service {
     fn call(&self, req: Self::Request) -> Self::Future;
 
     /// Wrap this Service in a Middleware component.
-    fn wrap<M>(self, middleware: M) -> M::WrappedService where
-        M: Middleware<Self>,
-        Self: Sized,
+    fn wrap<M>(self, middleware: M) -> M::WrappedService
+        where M: Middleware<Self>,
+              Self: Sized,
     {
         middleware.wrap(self)
     }
@@ -126,6 +126,13 @@ pub trait NewService {
 
     /// Create and return a new service value.
     fn new_service(&self) -> io::Result<Self::Instance>;
+
+    fn wrap<M>(self, new_middleware: M) -> NewServiceWrapper<M, Self>
+        where M: NewMiddleware<Self::Instance>,
+              Self: Sized,
+    {
+        new_middleware.wrap(self)
+    }
 }
 
 impl<F, R> NewService for F

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 //!
 //! [the trait]: trait.Service.html
 
-#![deny(missing_docs)]
+//#![deny(missing_docs)]
 #![doc(html_root_url = "https://docs.rs/tokio-service/0.1")]
 
 extern crate futures;
@@ -17,6 +17,7 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 mod middleware;
+pub mod stream;
 
 pub use self::middleware::{Middleware, MiddlewareChain};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,10 @@ use std::io;
 use std::rc::Rc;
 use std::sync::Arc;
 
+mod middleware;
+
+pub use self::middleware::{Middleware, MiddlewareChain};
+
 /// An asynchronous function from `Request` to a `Response`.
 ///
 /// The `Service` trait is a simplified interface making it easy to write
@@ -79,66 +83,6 @@ use std::sync::Arc;
 /// println!("Redis response: {:?}", await(resp));
 /// ```
 ///
-/// # Middleware
-///
-/// More often than not, all the pieces needed for writing robust, scalable
-/// network applications are the same no matter the underlying protocol. By
-/// unifying the API for both clients and servers in a protocol agnostic way,
-/// it is possible to write middleware that provide these pieces in a
-/// reusable way.
-///
-/// For example, take timeouts as an example:
-///
-/// ```rust,ignore
-/// use tokio::Service;
-/// use futures::Future;
-/// use std::time::Duration;
-///
-/// // Not yet implemented, but soon :)
-/// use tokio::timer::{Timer, Expired};
-///
-/// pub struct Timeout<T> {
-///     upstream: T,
-///     delay: Duration,
-///     timer: Timer,
-/// }
-///
-/// impl<T> Timeout<T> {
-///     pub fn new(upstream: T, delay: Duration) -> Timeout<T> {
-///         Timeout {
-///             upstream: upstream,
-///             delay: delay,
-///             timer: Timer::default(),
-///         }
-///     }
-/// }
-///
-/// impl<T> Service for Timeout<T>
-///     where T: Service,
-///           T::Error: From<Expired>,
-/// {
-///     type Request = T::Request;
-///     type Response = T::Response;
-///     type Error = T::Error;
-///     type Future = Box<Future<Item = Self::Response, Error = Self::Error>>;
-///
-///     fn call(&self, req: Self::Req) -> Self::Future {
-///         let timeout = self.timer.timeout(self.delay)
-///             .and_then(|timeout| Err(Self::Error::from(timeout)));
-///
-///         self.upstream.call(req)
-///             .select(timeout)
-///             .map(|(v, _)| v)
-///             .map_err(|(e, _)| e)
-///             .boxed()
-///     }
-/// }
-///
-/// ```
-///
-/// The above timeout implementation is decoupled from the underlying protocol
-/// and is also decoupled from client or server concerns. In other words, the
-/// same timeout middleware could be used in either a client or a server.
 pub trait Service {
 
     /// Requests handled by the service.
@@ -155,6 +99,14 @@ pub trait Service {
 
     /// Process the request and return the response asynchronously.
     fn call(&self, req: Self::Request) -> Self::Future;
+
+    /// Wrap this Service in a Middleware component.
+    fn wrap<M>(self, middleware: M) -> M::WrappedService where
+        M: Middleware<Self>,
+        Self: Sized,
+    {
+        middleware.wrap(self)
+    }
 }
 
 /// Creates new `Service` values.

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -1,0 +1,138 @@
+use std::marker::PhantomData;
+
+use Service;
+
+/// Often, many of the pieces needed for writing network applications
+/// can be reused across multiple services. The `Middleware` trait can
+/// be used to write reusable components that can be applied to very
+/// different kinds of services; for example, it can be applied to
+/// services operating on different protocols, and to both the client
+/// and server side of a network transaction.
+///
+/// # Timeouts
+///
+/// Take timeouts as an example:
+///
+/// ```rust,ignore
+/// use tokio::Service;
+/// use tokio::Middleware;
+/// use futures::Future;
+/// use std::time::Duration;
+///
+/// // Not yet implemented, but soon :)
+/// use tokio::timer::{Timer, Expired};
+///
+///
+/// pub struct Timeout {
+///     delay: Duration,
+///     timer: Timer,
+/// }
+///
+/// impl Timeout {
+///     fn timeout(&self) -> impl Future<Item = (), Error = Expired> {
+///         self.timer.timeout(self.delay)
+///     }
+/// }
+/// 
+/// impl<S> Middleware<S> for Timeout
+///     where S: Service,
+///           S::Error: From<Expired>,
+/// {
+///     type WrappedService = TimeoutService<S>;
+///     
+///     fn wrap(self, upstream: S) -> TimeoutService<S> {
+///         TimeoutService { timeout: self, upstream }
+///     }
+/// }
+///
+///
+/// // This service implements the Timeout behavior.
+/// pub struct TimeoutService<S> {
+///     upstream: S,
+///     timeout: Timeout,
+/// }
+///
+/// impl<S> Service for TimeoutService<S>
+///     where S: Service,
+///           S::Error: From<Expired>,
+/// {
+///     type Request = S::Request;
+///     type Response = S::Response;
+///     type Error = S::Error;
+///     type Future = Box<Future<Item = Self::Response, Error = Self::Error>>;
+///
+///     fn call(&self, req: Self::Req) -> Self::Future {
+///         let timeout = self.timeout.timeout()
+///             .and_then(|timeout| Err(Self::Error::from(timeout)));
+///
+///         self.upstream.call(req)
+///             .select(timeout)
+///             .map(|(v, _)| v)
+///             .map_err(|(e, _)| e)
+///             .boxed()
+///     }
+/// }
+///
+/// ```
+///
+/// The above timeout implementation is decoupled from the underlying protocol
+/// and is also decoupled from client or server concerns. In other words, the
+/// same timeout middleware could be used in either a client or a server.
+pub trait Middleware<S: Service> {
+    /// The service produced by wrapping this middleware around another
+    /// service.
+    type WrappedService: Service;
+
+    /// Wrap the middlware around a Service it is able to wrap.
+    ///
+    /// This produces a service of the `WrappedService` associated
+    /// type, which itself is another service that could possibly be
+    /// wrapped in other middleware.
+    fn wrap(self, service: S) -> Self::WrappedService;
+
+    /// Chain two middleware together. The lefthand side of this
+    /// operation is the "inner" middleware and the righthand side is
+    /// the "outer" middleware.
+    ///
+    /// When wrapping a middleware chain around a service, first the
+    /// inner middleware is wrapped around that service, and then the
+    /// outer middleware is wrapped around the service produced by the
+    /// inner middleware.
+    ///
+    /// This allows you to build middleware chains before knowing
+    /// exactly which service that chain applies to.
+    fn chain<M>(self, middleware: M) -> MiddlewareChain<S, Self, M> where
+        M: Middleware<Self::WrappedService>,
+        Self: Sized,
+    {
+        MiddlewareChain {
+            inner_middleware: self,
+            outer_middleware: middleware,
+            _marker: PhantomData,
+        }
+    }
+}
+
+/// Two middleware, chained together. This type is produced by the
+/// `chain` method on the Middleware trait.
+pub struct MiddlewareChain<S, InnerM, OuterM> where
+    S: Service,
+    InnerM: Middleware<S>,
+    OuterM: Middleware<InnerM::WrappedService>,
+{
+    inner_middleware: InnerM,
+    outer_middleware: OuterM,
+    _marker: PhantomData<S>,
+}
+
+impl<S, InnerM, OuterM> Middleware<S> for MiddlewareChain<S, InnerM, OuterM> where
+    S: Service,
+    InnerM: Middleware<S>,
+    OuterM: Middleware<InnerM::WrappedService>,
+{
+    type WrappedService = OuterM::WrappedService;
+
+    fn wrap(self, service: S) -> Self::WrappedService {
+        service.wrap(self.inner_middleware).wrap(self.outer_middleware)
+    }
+}

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -115,20 +115,20 @@ pub trait Middleware<S: Service> {
 
 /// Two middleware, chained together. This type is produced by the
 /// `chain` method on the Middleware trait.
-pub struct MiddlewareChain<S, InnerM, OuterM> where
-    S: Service,
-    InnerM: Middleware<S>,
-    OuterM: Middleware<InnerM::WrappedService>,
+pub struct MiddlewareChain<S, InnerM, OuterM>
+    where S: Service,
+          InnerM: Middleware<S>,
+          OuterM: Middleware<InnerM::WrappedService>,
 {
     inner_middleware: InnerM,
     outer_middleware: OuterM,
     _marker: PhantomData<S>,
 }
 
-impl<S, InnerM, OuterM> Middleware<S> for MiddlewareChain<S, InnerM, OuterM> where
-    S: Service,
-    InnerM: Middleware<S>,
-    OuterM: Middleware<InnerM::WrappedService>,
+impl<S, InnerM, OuterM> Middleware<S> for MiddlewareChain<S, InnerM, OuterM>
+    where S: Service,
+          InnerM: Middleware<S>,
+          OuterM: Middleware<InnerM::WrappedService>,
 {
     type WrappedService = OuterM::WrappedService;
 

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -1,3 +1,4 @@
+use std::io;
 use std::marker::PhantomData;
 
 use Service;
@@ -135,4 +136,10 @@ impl<S, InnerM, OuterM> Middleware<S> for MiddlewareChain<S, InnerM, OuterM>
     fn wrap(self, service: S) -> Self::WrappedService {
         service.wrap(self.inner_middleware).wrap(self.outer_middleware)
     }
+}
+
+pub trait NewMiddleware<S: Service> {
+    type Instance: Middleware<S>;
+
+    fn new_middleware(&self) -> io::Result<Self::Instance>;
 }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,3 +1,4 @@
+use std::io;
 use std::marker::PhantomData;
 use std::rc::Rc;
 use std::sync::Arc;
@@ -50,6 +51,51 @@ impl<S: StreamService + ?Sized> StreamService for Arc<S> {
 
     fn call(&self, request: S::Request) -> S::Stream {
         (**self).call(request)
+    }
+}
+
+pub trait NewStreamService {
+    type Request;
+    type Response;
+    type Error;
+    type Instance: StreamService<Request = Self::Request, Response = Self::Response, Error = Self::Error>;
+
+    fn new_service(&self) -> io::Result<Self::Instance>;
+}
+
+impl<F, R> NewStreamService for F
+    where F: Fn() -> io::Result<R>,
+          R: StreamService,
+{
+    type Request = R::Request;
+    type Response = R::Response;
+    type Error = R::Error;
+    type Instance = R;
+
+    fn new_service(&self) -> io::Result<R> {
+        (*self)()
+    }
+}
+
+impl<S: NewStreamService + ?Sized> NewStreamService for Arc<S> {
+    type Request = S::Request;
+    type Response = S::Response;
+    type Error = S::Error;
+    type Instance = S::Instance;
+
+    fn new_service(&self) -> io::Result<S::Instance> {
+        (**self).new_service()
+    }
+}
+
+impl<S: NewStreamService + ?Sized> NewStreamService for Rc<S> {
+    type Request = S::Request;
+    type Response = S::Response;
+    type Error = S::Error;
+    type Instance = S::Instance;
+
+    fn new_service(&self) -> io::Result<S::Instance> {
+        (**self).new_service()
     }
 }
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,0 +1,93 @@
+use std::marker::PhantomData;
+use std::rc::Rc;
+use std::sync::Arc;
+
+use futures::Stream;
+
+pub trait StreamService {
+    type Request;
+    type Response;
+    type Error;
+    type Stream: Stream<Item = Self::Response, Error = Self::Error>;
+
+    fn call(&self, req: Self::Request) -> Self::Stream;
+
+    fn wrap<M>(self, middleware: M) -> M::WrappedService
+        where M: StreamMiddleware<Self>,
+              Self: Sized,
+    {
+        middleware.wrap(self)
+    }
+}
+
+impl<S: StreamService + ?Sized> StreamService for Box<S> {
+    type Request = S::Request;
+    type Response = S::Response;
+    type Error = S::Error;
+    type Stream = S::Stream;
+
+    fn call(&self, request: S::Request) -> S::Stream {
+        (**self).call(request)
+    }
+}
+
+impl<S: StreamService + ?Sized> StreamService for Rc<S> {
+    type Request = S::Request;
+    type Response = S::Response;
+    type Error = S::Error;
+    type Stream = S::Stream;
+
+    fn call(&self, request: S::Request) -> S::Stream {
+        (**self).call(request)
+    }
+}
+
+impl<S: StreamService + ?Sized> StreamService for Arc<S> {
+    type Request = S::Request;
+    type Response = S::Response;
+    type Error = S::Error;
+    type Stream = S::Stream;
+
+    fn call(&self, request: S::Request) -> S::Stream {
+        (**self).call(request)
+    }
+}
+
+pub trait StreamMiddleware<S: StreamService> {
+    type WrappedService: StreamService;
+
+    fn wrap(self, service: S) -> Self::WrappedService;
+
+    fn chain<M>(self, middleware: M) -> StreamMiddlewareChain<S, Self, M>
+        where M: StreamMiddleware<Self::WrappedService>,
+              Self: Sized,
+    {
+        StreamMiddlewareChain {
+            inner_middleware: self,
+            outer_middleware: middleware,
+            _marker: PhantomData,
+        }
+    }
+}
+
+pub struct StreamMiddlewareChain<S, InnerM, OuterM>
+    where S: StreamService,
+          InnerM: StreamMiddleware<S>,
+          OuterM: StreamMiddleware<InnerM::WrappedService>,
+{
+    inner_middleware: InnerM,
+    outer_middleware: OuterM,
+    _marker: PhantomData<S>,
+}
+
+impl<S, InnerM, OuterM> StreamMiddleware<S> for StreamMiddlewareChain<S, InnerM, OuterM>
+    where S: StreamService,
+          InnerM: StreamMiddleware<S>,
+          OuterM: StreamMiddleware<InnerM::WrappedService>,
+{
+    type WrappedService = OuterM::WrappedService;
+
+    fn wrap(self, service: S) -> Self::WrappedService {
+        service.wrap(self.inner_middleware).wrap(self.outer_middleware)
+    }
+}

--- a/src/stream/middleware.rs
+++ b/src/stream/middleware.rs
@@ -1,3 +1,4 @@
+use std::io;
 use std::marker::PhantomData;
 
 use {Middleware, Service};
@@ -116,10 +117,10 @@ impl<S, R, M> StreamReduce<S> for StreamReduceMiddlewareChain<S, R, M>
 
 pub trait NewStreamMiddleware<S: StreamService> {
     type Instance: StreamMiddleware<S>;
-    fn new_middleware(&self) -> Self::Instance;
+    fn new_middleware(&self) -> io::Result<Self::Instance>;
 }
 
 pub trait NewStreamReduce<S: StreamService> {
     type Instance: StreamReduce<S>;
-    fn new_reducer(&self) -> Self::Instance;
+    fn new_reducer(&self) -> io::Result<Self::Instance>;
 }

--- a/src/stream/middleware.rs
+++ b/src/stream/middleware.rs
@@ -113,3 +113,13 @@ impl<S, R, M> StreamReduce<S> for StreamReduceMiddlewareChain<S, R, M>
         service.reduce(self.reducer).wrap(self.middleware)
     }
 }
+
+pub trait NewStreamMiddleware<S: StreamService> {
+    type Instance: StreamMiddleware<S>;
+    fn new_middleware(&self) -> Self::Instance;
+}
+
+pub trait NewStreamReduce<S: StreamService> {
+    type Instance: StreamReduce<S>;
+    fn new_reducer(&self) -> Self::Instance;
+}

--- a/src/stream/middleware.rs
+++ b/src/stream/middleware.rs
@@ -1,0 +1,115 @@
+use std::marker::PhantomData;
+
+use {Middleware, Service};
+use stream::StreamService;
+
+pub trait StreamMiddleware<S: StreamService> {
+    type WrappedService: StreamService;
+
+    fn wrap(self, service: S) -> Self::WrappedService;
+
+    fn chain<M>(self, middleware: M) -> StreamMiddlewareChain<S, Self, M>
+        where M: StreamMiddleware<Self::WrappedService>,
+              Self: Sized,
+    {
+        StreamMiddlewareChain {
+            inner_middleware: self,
+            outer_middleware: middleware,
+            _marker: PhantomData,
+        }
+    }
+
+    fn reduce<R>(self, reducer: R) -> StreamMiddlewareReduceChain<S, Self, R>
+        where R: StreamReduce<Self::WrappedService>,
+              Self: Sized,
+    {
+        StreamMiddlewareReduceChain {
+            middleware: self,
+            reducer: reducer,
+            _marker: PhantomData,
+        }
+    }
+}
+
+pub struct StreamMiddlewareChain<S, InnerM, OuterM>
+    where S: StreamService,
+          InnerM: StreamMiddleware<S>,
+          OuterM: StreamMiddleware<InnerM::WrappedService>,
+{
+    inner_middleware: InnerM,
+    outer_middleware: OuterM,
+    _marker: PhantomData<S>,
+}
+
+impl<S, InnerM, OuterM> StreamMiddleware<S> for StreamMiddlewareChain<S, InnerM, OuterM>
+    where S: StreamService,
+          InnerM: StreamMiddleware<S>,
+          OuterM: StreamMiddleware<InnerM::WrappedService>,
+{
+    type WrappedService = OuterM::WrappedService;
+
+    fn wrap(self, service: S) -> Self::WrappedService {
+        service.wrap(self.inner_middleware).wrap(self.outer_middleware)
+    }
+}
+
+pub trait StreamReduce<S: StreamService> {
+    type ReducedService: Service;
+
+    fn reduce(self, service: S) -> Self::ReducedService;
+
+    fn chain<M>(self, middleware: M) -> StreamReduceMiddlewareChain<S, Self, M>
+        where M: Middleware<Self::ReducedService>,
+              Self: Sized,
+    {
+        StreamReduceMiddlewareChain {
+            reducer: self,
+            middleware: middleware,
+            _marker: PhantomData,
+        }
+    }
+}
+
+pub struct StreamMiddlewareReduceChain<S, M, R>
+    where S: StreamService,
+          M: StreamMiddleware<S>,
+          R: StreamReduce<M::WrappedService>,
+{
+    middleware: M,
+    reducer: R,
+    _marker: PhantomData<S>,
+}
+
+impl<S, M, R> StreamReduce<S> for StreamMiddlewareReduceChain<S, M, R>
+    where S: StreamService,
+          M: StreamMiddleware<S>,
+          R: StreamReduce<M::WrappedService>,
+{
+    type ReducedService = R::ReducedService;
+
+    fn reduce(self, service: S) -> Self::ReducedService {
+        service.wrap(self.middleware).reduce(self.reducer)
+    }
+}
+
+pub struct StreamReduceMiddlewareChain<S, R, M>
+    where S: StreamService,
+          R: StreamReduce<S>,
+          M: Middleware<R::ReducedService>,
+{
+    reducer: R,
+    middleware: M,
+    _marker: PhantomData<S>,
+}
+
+impl<S, R, M> StreamReduce<S> for StreamReduceMiddlewareChain<S, R, M>
+    where S: StreamService,
+          R: StreamReduce<S>,
+          M: Middleware<R::ReducedService>,
+{
+    type ReducedService = M::WrappedService;
+
+    fn reduce(self, service: S) -> Self::ReducedService {
+        service.reduce(self.reducer).wrap(self.middleware)
+    }
+}

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -73,6 +73,20 @@ pub trait NewStreamService {
     type Instance: StreamService<Request = Self::Request, Response = Self::Response, Error = Self::Error>;
 
     fn new_service(&self) -> io::Result<Self::Instance>;
+
+    fn wrap<M>(self, new_middleware: M) -> NewStreamServiceWrapper<M, Self>
+        where M: NewStreamMiddleware<Self::Instance>,
+              Self: Sized,
+    {
+        new_middleware.wrap(self)
+    }
+
+    fn reduce<R>(self, new_reducer: R) -> NewStreamServiceReducer<R, Self>
+        where R: NewStreamReduce<Self::Instance>,
+              Self: Sized,
+    {
+        new_reducer.reduce(self)
+    }
 }
 
 impl<F, R> NewStreamService for F

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -1,6 +1,8 @@
 mod middleware;
+mod reduce;
 
 pub use self::middleware::*;
+pub use self::reduce::*;
 
 use std::io;
 use std::rc::Rc;

--- a/src/stream/reduce.rs
+++ b/src/stream/reduce.rs
@@ -1,0 +1,117 @@
+use std::io;
+use std::marker::PhantomData;
+
+use {Middleware, NewMiddleware, Service, NewService};
+use stream::{StreamService, NewStreamService};
+
+pub trait StreamReduce<S: StreamService> {
+    type ReducedService: Service;
+
+    fn reduce(self, service: S) -> Self::ReducedService;
+
+    fn chain<M>(self, middleware: M) -> StreamReduceMiddlewareChain<S, Self, M>
+        where M: Middleware<Self::ReducedService>,
+              Self: Sized,
+    {
+        StreamReduceMiddlewareChain {
+            reducer: self,
+            middleware: middleware,
+            _marker: PhantomData,
+        }
+    }
+}
+
+pub struct StreamReduceMiddlewareChain<S, R, M>
+    where S: StreamService,
+          R: StreamReduce<S>,
+          M: Middleware<R::ReducedService>,
+{
+    reducer: R,
+    middleware: M,
+    _marker: PhantomData<S>,
+}
+
+impl<S, R, M> StreamReduce<S> for StreamReduceMiddlewareChain<S, R, M>
+    where S: StreamService,
+          R: StreamReduce<S>,
+          M: Middleware<R::ReducedService>,
+{
+    type ReducedService = M::WrappedService;
+
+    fn reduce(self, service: S) -> Self::ReducedService {
+        service.reduce(self.reducer).wrap(self.middleware)
+    }
+}
+
+pub trait NewStreamReduce<S: StreamService> {
+    type ReducedService: Service;
+    type Instance: StreamReduce<S, ReducedService = Self::ReducedService>;
+
+    fn new_reducer(&self) -> io::Result<Self::Instance>;
+
+    fn reduce<N>(self, new_service: N) -> NewStreamServiceReducer<Self, N>
+        where N: NewStreamService<Instance = S, Request = S::Request, Response = S::Response, Error = S::Error>,
+              Self: Sized,
+    {
+        NewStreamServiceReducer {
+            service: new_service,
+            reducer: self,
+        }
+    }
+
+    fn chain<M>(self, new_middleware: M) -> NewStreamReduceMiddlewareChain<S, Self, M>
+        where M: NewMiddleware<Self::ReducedService>,
+              Self: Sized,
+    {
+        NewStreamReduceMiddlewareChain {
+            reducer: self,
+            middleware: new_middleware,
+            _marker: PhantomData,
+        }
+    }
+}
+
+pub struct NewStreamServiceReducer<R: NewStreamReduce<S::Instance>, S: NewStreamService> {
+    service: S,
+    reducer: R,
+}
+
+impl<R, S, W> NewService for NewStreamServiceReducer<R, S>
+    where S: NewStreamService,
+          R: NewStreamReduce<S::Instance, ReducedService = W>,
+          W: Service,
+{
+    type Request = W::Request;
+    type Response = W::Response;
+    type Error = W::Error;
+    type Instance = W;
+
+    fn new_service(&self) -> io::Result<Self::Instance> {
+        Ok(self.service.new_service()?.reduce(self.reducer.new_reducer()?))
+    }
+}
+
+pub struct NewStreamReduceMiddlewareChain<S, R, M>
+where
+    S: StreamService,
+    R: NewStreamReduce<S>,
+    M: NewMiddleware<R::ReducedService>,
+{
+    reducer: R,
+    middleware: M,
+    _marker: PhantomData<S>,
+}
+
+impl<S, R, M> NewStreamReduce<S> for NewStreamReduceMiddlewareChain<S, R, M>
+where
+    S: StreamService,
+    R: NewStreamReduce<S>,
+    M: NewMiddleware<R::ReducedService>,
+{
+    type ReducedService = M::WrappedService;
+    type Instance = StreamReduceMiddlewareChain<S, R::Instance, M::Instance>;
+
+    fn new_reducer(&self) -> io::Result<Self::Instance> {
+        Ok(self.reducer.new_reducer()?.chain(self.middleware.new_middleware()?))
+    }
+}

--- a/src/stream/reduce.rs
+++ b/src/stream/reduce.rs
@@ -1,5 +1,4 @@
 use std::io;
-use std::marker::PhantomData;
 
 use {Middleware, NewMiddleware, Service, NewService};
 use stream::{StreamService, NewStreamService};
@@ -9,29 +8,23 @@ pub trait StreamReduce<S: StreamService> {
 
     fn reduce(self, service: S) -> Self::ReducedService;
 
-    fn chain<M>(self, middleware: M) -> StreamReduceMiddlewareChain<S, Self, M>
+    fn chain<M>(self, middleware: M) -> StreamReduceMiddlewareChain<Self, M>
         where M: Middleware<Self::ReducedService>,
               Self: Sized,
     {
         StreamReduceMiddlewareChain {
             reducer: self,
             middleware: middleware,
-            _marker: PhantomData,
         }
     }
 }
 
-pub struct StreamReduceMiddlewareChain<S, R, M>
-    where S: StreamService,
-          R: StreamReduce<S>,
-          M: Middleware<R::ReducedService>,
-{
+pub struct StreamReduceMiddlewareChain<R, M> {
     reducer: R,
     middleware: M,
-    _marker: PhantomData<S>,
 }
 
-impl<S, R, M> StreamReduce<S> for StreamReduceMiddlewareChain<S, R, M>
+impl<S, R, M> StreamReduce<S> for StreamReduceMiddlewareChain<R, M>
     where S: StreamService,
           R: StreamReduce<S>,
           M: Middleware<R::ReducedService>,
@@ -59,14 +52,13 @@ pub trait NewStreamReduce<S: StreamService> {
         }
     }
 
-    fn chain<M>(self, new_middleware: M) -> NewStreamReduceMiddlewareChain<S, Self, M>
+    fn chain<M>(self, new_middleware: M) -> NewStreamReduceMiddlewareChain<Self, M>
         where M: NewMiddleware<Self::ReducedService>,
               Self: Sized,
     {
         NewStreamReduceMiddlewareChain {
             reducer: self,
             middleware: new_middleware,
-            _marker: PhantomData,
         }
     }
 }
@@ -91,25 +83,19 @@ impl<R, S, W> NewService for NewStreamServiceReducer<R, S>
     }
 }
 
-pub struct NewStreamReduceMiddlewareChain<S, R, M>
-where
-    S: StreamService,
-    R: NewStreamReduce<S>,
-    M: NewMiddleware<R::ReducedService>,
-{
+pub struct NewStreamReduceMiddlewareChain<R, M> {
     reducer: R,
     middleware: M,
-    _marker: PhantomData<S>,
 }
 
-impl<S, R, M> NewStreamReduce<S> for NewStreamReduceMiddlewareChain<S, R, M>
+impl<S, R, M> NewStreamReduce<S> for NewStreamReduceMiddlewareChain<R, M>
 where
     S: StreamService,
     R: NewStreamReduce<S>,
     M: NewMiddleware<R::ReducedService>,
 {
     type ReducedService = M::WrappedService;
-    type Instance = StreamReduceMiddlewareChain<S, R::Instance, M::Instance>;
+    type Instance = StreamReduceMiddlewareChain<R::Instance, M::Instance>;
 
     fn new_reducer(&self) -> io::Result<Self::Instance> {
         Ok(self.reducer.new_reducer()?.chain(self.middleware.new_middleware()?))


### PR DESCRIPTION
## Middleware

This PR adds a Middleware trait (different from the Middleware trait proposed in #17). This trait is intended to be the lowest common denominator of different middleware shapes: its literally isomorphic to `FnOnce(Service) -> Service`:

```rust
trait Middleware<S: Service> {
    type WrappedService: Service;
    fn wrap(self, service: S) -> Self::WrappedService;
}
```

This supports the following operations:

* `wrap` (analogous to `apply`). `Service -> Middleware -> Service`. This is user supplied on each middleware trait, and Service contains a default method to do it as well.

* `chain` (analogous to `compose`). `Middleware -> Middleware -> Middleware`. Combine two middleware to create a new middlware. This is provided through a default method on Middleware.

Users therefore have a fairly convenient API of `middleware.chain(middleware).wrap(service)` or `service.wrap(middleware).wrap(middleware)`, depending on what values they have in context at that moment.

## Streams

This also adds `StreamService` and `StreamMiddleware`, analogous to `Service` and `Middleware` except that they yield streams of responses instead of futures. Literally some trait bounds are the only difference between these traits and their non-stream analogs (note: use case for ConstraintKinds someday?).

## Stream Reducers

The last piece of this is the `StreamReduce` trait, which is similar to a middleware except that it is a function of `StreamService -> Service`. This way you can deal with a stream at one layer of the stack & collapse it into a future at another layer.

Stream reducers can be composed with both StreamMiddleware and Middleware to produce another stream reducer.

## Future extensions

Given that this has `Service -> Service`, `StreamService -> StreamService`, and `StreamService -> Service`, its clearly missing a `Service -> StreamService` (`ServiceUnfold`?). Time will tell if that's actually a useful trait.

The middleware definition here is the "LCD," probable we will want to explore different higher level abstractions on top of it for "before / after / around" middleware patterns. But this seems like the baseline that any of those will have to be built on top of.