### PR TITLE
Improve wording in documentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,7 @@ use std::sync::Arc;
 /// it is possible to write middleware that provide these pieces in a
 /// reusable way.
 ///
-/// For example, take timeouts as an example:
+/// Take timeouts as an example:
 ///
 /// ```rust,ignore
 /// use tokio::Service;


### PR DESCRIPTION
Remove redundant wording form documentation.